### PR TITLE
Update jsonwebtoken v8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 base64        = "0.13"
 bitflags      = "1.2"
 generic-array = "0.14"
-jsonwebtoken  = { version = "7.2", optional = true }
+jsonwebtoken  = { version = "8.0", optional = true }
 num-bigint    = { version = "0.4", optional = true }
 p256          = { version = "0.9", optional = true, features = ["arithmetic"] }
 rand          = { version = "0.8", optional = true }
@@ -29,7 +29,7 @@ jwt-convert  = ["pkcs-convert", "jsonwebtoken"]
 generate     = ["p256", "rand"]
 
 [dev-dependencies]
-jsonwebtoken = "7.2"
+jsonwebtoken = "8.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -85,7 +85,7 @@ mod tests {
     static BASE64_JSON: &str = "\"AQIDBAUGBw\"";
 
     fn get_de() -> serde_json::Deserializer<serde_json::de::StrRead<'static>> {
-        serde_json::Deserializer::from_str(&BASE64_JSON)
+        serde_json::Deserializer::from_str(BASE64_JSON)
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@
 //! extern crate jsonwebkey as jwk;
 //!
 //! #[derive(serde::Serialize, serde::Deserialize)]
-//! struct TokenClaims {}
+//! struct TokenClaims {
+//!     exp: usize,
+//! }
 //!
 //! let mut my_jwk = jwk::JsonWebKey::new(jwk::Key::generate_p256());
 //! my_jwk.set_algorithm(jwk::Algorithm::ES256);
@@ -40,7 +42,9 @@
 //! let alg: jwt::Algorithm = my_jwk.algorithm.unwrap().into();
 //! let token = jwt::encode(
 //!     &jwt::Header::new(alg),
-//!     &TokenClaims {},
+//!     &TokenClaims {
+//!         exp: 0,
+//!     },
 //!     &my_jwk.key.to_encoding_key(),
 //! ).unwrap();
 //!
@@ -333,9 +337,7 @@ impl Key {
 
                 match private {
                     Some(
-                        private
-                        @
-                        RsaPrivate {
+                        private @ RsaPrivate {
                             d: _,
                             p: Some(_),
                             q: Some(_),
@@ -577,20 +579,19 @@ const _IMPL_JWT_CONVERSIONS: () = {
             self.try_to_encoding_key().unwrap()
         }
 
-        pub fn to_decoding_key(&self) -> jwt::DecodingKey<'static> {
+        pub fn to_decoding_key(&self) -> jwt::DecodingKey {
             match self {
-                Self::Symmetric { key } => jwt::DecodingKey::from_secret(key).into_static(),
+                Self::Symmetric { key } => jwt::DecodingKey::from_secret(key),
                 Self::EC { .. } => {
                     // The following will not panic: all EC JWKs have public components due to
                     // typing. PEM conversion will always succeed, for the same reason.
                     // Hence, jwt::DecodingKey shall have no issue with de-converting.
                     jwt::DecodingKey::from_ec_pem(self.to_public().unwrap().to_pem().as_bytes())
                         .unwrap()
-                        .into_static()
                 }
-                Self::RSA { .. } => jwt::DecodingKey::from_rsa_pem(self.to_pem().as_bytes())
-                    .unwrap()
-                    .into_static(),
+                Self::RSA { .. } => {
+                    jwt::DecodingKey::from_rsa_pem(self.to_pem().as_bytes()).unwrap()
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ impl Key {
                 ]);
                 let oids = &[Some(&rsa_encryption_oid), None];
                 let write_bytevec = |writer: DERWriter<'_>, vec: &ByteVec| {
-                    let bigint = BigUint::from_bytes_be(&vec);
+                    let bigint = BigUint::from_bytes_be(vec);
                     writer.write_biguint(&bigint);
                 };
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -97,7 +97,9 @@ fn generate_p256() {
     extern crate jsonwebtoken as jwt;
 
     #[derive(Serialize, Deserialize)]
-    struct TokenClaims {}
+    struct TokenClaims {
+        exp: usize,
+    }
 
     let mut the_jwk = JsonWebKey::new(Key::generate_p256());
     the_jwk.set_algorithm(Algorithm::ES256).unwrap();
@@ -105,7 +107,7 @@ fn generate_p256() {
     let encoding_key = jwt::EncodingKey::from_ec_der(&the_jwk.key.to_der());
     let token = jwt::encode(
         &jwt::Header::new(the_jwk.algorithm.unwrap().into()),
-        &TokenClaims {},
+        &TokenClaims { exp: 0 },
         &encoding_key,
     )
     .unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,7 +33,7 @@ pub(crate) mod serde_base64 {
             let err_msg = e.to_string().to_lowercase();
             #[cfg(not(debug_assertions))]
             let err_msg = "invalid base64";
-            de::Error::custom(err_msg.strip_suffix(".").unwrap_or(&err_msg))
+            de::Error::custom(err_msg.strip_suffix('.').unwrap_or(&err_msg))
         })
     }
 }


### PR DESCRIPTION
This updates jsonwebtoken to version 8.0, and also includes a few clippy fixes.