### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 base64        = "0.13"
 bitflags      = "1.2"
 generic-array = "0.14"
-jsonwebtoken  = { version = "8.0",  optional = true }
+jsonwebtoken  = { version = "9.0",  optional = true }
 num-bigint    = { version = "0.4",  optional = true }
 p256          = { version = "0.10", optional = true, features = ["arithmetic"] }
 rand          = { version = "0.8",  optional = true }
@@ -31,7 +31,7 @@ generate     = ["p256", "rand"]
 thumbprint   = ["sha2"]
 
 [dev-dependencies]
-jsonwebtoken = "8.0"
+jsonwebtoken = "9.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-base64        = "0.13"
+base64        = "0.21"
 bitflags      = "1.2"
 generic-array = "0.14"
 jsonwebtoken  = { version = "9.0",  optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 base64        = "0.21"
-bitflags      = "1.2"
+bitflags      = "2.4"
 generic-array = "0.14"
 jsonwebtoken  = { version = "9.0",  optional = true }
 num-bigint    = { version = "0.4",  optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bitflags      = "1.2"
 generic-array = "0.14"
 jsonwebtoken  = { version = "9.0",  optional = true }
 num-bigint    = { version = "0.4",  optional = true }
-p256          = { version = "0.10", optional = true, features = ["arithmetic"] }
+p256          = { version = "0.13", optional = true, features = ["arithmetic"] }
 rand          = { version = "0.8",  optional = true }
 serde         = { version = "1.0",  features = ["derive"] }
 serde_json    = "1.0"

--- a/src/key_ops.rs
+++ b/src/key_ops.rs
@@ -6,7 +6,7 @@ use serde::{
 macro_rules! impl_key_ops {
     ($(($key_op:ident, $const_name:ident, $i:literal)),+,) => {
         bitflags::bitflags! {
-            #[derive(Default)]
+            #[derive(Debug, Clone, PartialEq, Eq, Default)]
             pub struct KeyOps: u16 {
                 $(const $const_name = $i;)*
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,8 +411,9 @@ impl Key {
     /// If this key is asymmetric, encodes it as PKCS#8 with PEM armoring.
     #[cfg(feature = "pkcs-convert")]
     pub fn try_to_pem(&self) -> Result<String, ConversionError> {
+        use base64::{engine::general_purpose::STANDARD, Engine};
         use std::fmt::Write;
-        let der_b64 = base64::encode(self.try_to_der()?);
+        let der_b64 = STANDARD.encode(self.try_to_der()?);
         let key_ty = if self.is_private() {
             "PRIVATE"
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl JsonWebKey {
     }
 
     pub fn set_algorithm(&mut self, alg: Algorithm) -> Result<(), Error> {
-        Self::validate_algorithm(alg, &*self.key)?;
+        Self::validate_algorithm(alg, &self.key)?;
         self.algorithm = Some(alg);
         Ok(())
     }
@@ -180,7 +180,7 @@ impl std::str::FromStr for JsonWebKey {
             Some(alg) => alg,
             None => return Ok(jwk),
         };
-        Self::validate_algorithm(alg, &*jwk.key).map(|_| jwk)
+        Self::validate_algorithm(alg, &jwk.key).map(|_| jwk)
     }
 }
 
@@ -337,7 +337,7 @@ impl Key {
                     Some(private_point) => {
                         pkcs8::write_private(oids, |writer: &mut DERWriterSeq<'_>| {
                             writer.next().write_i8(1); // version
-                            writer.next().write_bytes(&**private_point);
+                            writer.next().write_bytes(private_point);
                             // The following tagged value is optional. OpenSSL produces it,
                             // but many tools, including jwt.io and `jsonwebtoken`, don't like it,
                             // so we don't include it.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,19 +1,24 @@
+use base64::{
+    alphabet::URL_SAFE,
+    engine::{general_purpose::NO_PAD, GeneralPurpose},
+    Engine,
+};
 use serde::{
     de::{self, Deserialize, Deserializer},
     ser::{Serialize, Serializer},
 };
 use zeroize::Zeroizing;
 
-fn base64_config() -> base64::Config {
-    base64::Config::new(base64::CharacterSet::UrlSafe, false /* pad */)
+fn base64_config() -> GeneralPurpose {
+    GeneralPurpose::new(&URL_SAFE, NO_PAD)
 }
 
 pub(crate) fn base64_encode(bytes: impl AsRef<[u8]>) -> String {
-    base64::encode_config(bytes, base64_config())
+    base64_config().encode(bytes)
 }
 
 fn base64_decode(b64: impl AsRef<[u8]>) -> Result<Vec<u8>, base64::DecodeError> {
-    base64::decode_config(b64, base64_config())
+    base64_config().decode(b64)
 }
 
 pub(crate) mod serde_base64 {


### PR DESCRIPTION
Thanks for the crate, it saved me quite a bit of time!
Using it I noticed it's not compatible with the latest `jsonwebtoken` v0.9.1. 

Here's a patch to update all dependencies (except for generic-array, since p256 is sticking to 0.14)