### PR TITLE
fix: to_decoding_key should use to_public for RSA

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,7 +635,8 @@ const _IMPL_JWT_CONVERSIONS: () = {
                         .unwrap()
                 }
                 Self::RSA { .. } => {
-                    jwt::DecodingKey::from_rsa_pem(self.to_pem().as_bytes()).unwrap()
+                    jwt::DecodingKey::from_rsa_pem(self.to_public().unwrap().to_pem().as_bytes())
+                        .unwrap()
                 }
             }
         }


### PR DESCRIPTION
I'm not sure why `jsonwebtoken` crate is ok with that, but the resulting `DecodingKey` returns `InvalidSignature` error when the original code is used.